### PR TITLE
fix Cannot evaluate expression: Invalid macro '{}' value messages 

### DIFF
--- a/template_sensors.xml
+++ b/template_sensors.xml
@@ -440,6 +440,14 @@
             <httptests/>
             <macros>
                 <macro>
+                    <macro>{$SENSORS_HIGH}</macro>
+                    <value>0</value>
+                </macro>
+                <macro>
+                    <macro>{$SENSORS_CRIT}</macro>
+                    <value>0</value>
+                </macro>
+                <macro>
                     <macro>{$SENSORS_FAN_STOP_TRIG}</macro>
                     <value>0</value>
                 </macro>


### PR DESCRIPTION
after clean template import