### PR TITLE
Resolve issues when nouveau is used and improve error handling

### DIFF
--- a/sensors.py
+++ b/sensors.py
@@ -1,22 +1,33 @@
 #!/usr/bin/env python3
 
+import errno
 import json
 import re
 import os
+import sys
 
 DIR = "/sys/class/hwmon"
 
 
 def read(fn):
-    with open(fn) as f:
-        return f.read()
+    try:
+        with open(fn) as f:
+            return f.read()
+    except OSError as e:
+        # in some cases nouveau might return EINVAL when GPU is not in use
+        # We are defaulting to 0 when the value cannot be read
+        # https://github.com/torvalds/linux/blob/v6.9/drivers/gpu/drm/nouveau/nouveau_hwmon.c#L379
+        if e.errno == errno.EINVAL:
+            return '0'
+        else:
+            raise
 
 
 def read_parse(fn):
     x = read(fn).strip()
     try:
         return int(x)
-    except BaseException:
+    except ValueError:
         return x
 
 
@@ -51,14 +62,23 @@ def process_hwmon(n):
     return name, process_sensors(path)
 
 
-r = {}
+def main():
+    r = {}
 
-for hwm in list_hwmon():
-    name, sensors = process_hwmon(hwm)
-    if not sensors:
-        continue
+    for hwm in list_hwmon():
+        try:
+            name, sensors = process_hwmon(hwm)
+        except Exception as e:
+            sys.stderr.write(f"Failure to process {hwm}: {e}\n")
+            continue
+        if not sensors:
+            continue
 
-    name = f"{hwm}-{name}"
-    r[name] = sensors
+        name = f"{hwm}-{name}"
+        r[name] = sensors
 
-print(json.dumps(r, indent=2, sort_keys=True))
+    print(json.dumps(r, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR:
  - Ensures that the inability to read some values does not fail the whole script. If there is an issue, a message will be printed to stderr.
  - Returns 0 whenever a value cannot be accessed (e.g in case when nouveau is used)
  - Improves error handling in read_parse to be more precise
  - Refactors the code to use a main function

An example output of the script in case noveau is in use, but GPU is disabled:
```
{
...
  "hwmon4-nouveau": {
    "in0": {
      "input": 0,
      "label": "GPU core",
      "max": 1200,
      "min": 600,
      "sensor_type": "in"
    },
    "temp1": {
      "auto_point1_pwm": 100,
      "auto_point1_temp": 90000,
      "auto_point1_temp_hyst": 3000,
      "crit": 105000,
      "crit_hyst": 5000,
      "emergency": 135000,
      "emergency_hyst": 5000,
      "input": 0,
      "max": 95000,
      "max_hyst": 3000,
      "sensor_type": "temp"
    }
  }
}
```