### PR TITLE
ensure the name for block devices is deterministic

### DIFF
--- a/sensors.py
+++ b/sensors.py
@@ -77,10 +77,14 @@ def process_hwmon(n):
     raw_devlinks = glob.glob("/dev/disk/by-id/*")
     devlinks = list(filter(lambda x: not re.search("^nvme-eui|^nvme-nvme|^wwn-0x|^scsi-[0-9]", os.path.basename(x)), raw_devlinks))
     if blockdev:
+        blockname = None
         for devlink in devlinks:
             if os.path.islink(devlink) and blockdev==os.path.basename(os.readlink(devlink)):
-                name = os.path.basename(devlink)
-                break
+                devlink_name = os.path.basename(devlink)
+                if blockname is None or devlink_name > blockname:
+                    blockname = devlink_name
+        if blockname:
+            name = blockname
 
     return name, process_sensors(path)
 


### PR DESCRIPTION
NVMe devices have more than one entry under `/dev/disk/by-id`. This may cause sensors.py to select a different name from one reboot to the next, and ultimately duplicate items in Zabbix's discovery.

We now choose the last entry in lexicographic order, which ensures determinism and prefers the one with namespace information.

See also: https://unix.stackexchange.com/a/752948a .