### PR TITLE
allow item name customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,38 @@ Zabbix template &amp; scripts to discover &amp; monitor Linux sensors
 - Python3
 
 ## Macros
+
+### Trigger values
+
 - `{$SENSORS_FAN_LOW}`: Low fan speed sensor threshold
 - `{$SENSORS_TEMP_CRIT}`: Crit value for temp sensors
 - `{$SENSORS_TEMP_HIGH}`: High value for temp sensors
 - `{$SENSORS_TEMP_HYST}`: Hysteresis for temp sensors to make sure that trigger is not firing when value oscillates over threshold and back
 - `{$SENSORS_VOLTAGE_HIGH}`: Voltage high threshold
 - `{$SENSORS_VOLTAGE_LOW}`: Voltage low threshold
+
+All `*_LOW`, `*_HIGH`, and `*_CRIT` macros can also be set per sensor as
+described below.
+
+### Customizing discovered item names
+
+Having all your items named `Fan 'it8688' - 'fan1'`, `Fan 'it8688' - 'fan2'` etc. can be confusing.
+
+To rename the first item as `Front case fan 'it8688' - 'fan1'`, set a macro on the host:
+
+```
+{$SENSORS_FAN_NAME:"it8688_fan1"} = Front case fan
+```
+
+Set as much macros as you have sensors to rename. Use the macro name matching the sensor type:
+
+- `{$SENSORS_FAN_NAME}`
+- `{$SENSORS_TEMP_NAME}`
+- `{$SENSORS_POWER_NAME}`
+- `{$SENSORS_VOLTAGE_NAME}`
+
+See [Zabbix's documentation](https://www.zabbix.com/documentation/current/en/manual/config/macros/user_macros_context)
+for more information about user macros with context.
 
 ## Update 2023-06
 

--- a/template_sensors_7.4.xml
+++ b/template_sensors_7.4.xml
@@ -42,7 +42,7 @@
                     <item_prototypes>
                         <item_prototype>
                             <uuid>a04c66a84f894cb5a7c4080de4bca288</uuid>
-                            <name>Fan '{#DRIVER}' - '{#LABEL}'</name>
+                            <name>{$SENSORS_FAN_NAME:&quot;{#DRIVER}_{#SENSOR}&quot;} '{#DRIVER}' - '{#LABEL}'</name>
                             <type>DEPENDENT</type>
                             <key>sensors.fan['{#DRIVER}', '{#SENSOR}']</key>
                             <history>30d</history>
@@ -72,7 +72,7 @@
                                 <trigger_prototype>
                                     <uuid>14bff65404db4e7ea722a124d4ec42f6</uuid>
                                     <expression>last(/Sensors/sensors.fan['{#DRIVER}', '{#SENSOR}'])&lt;{$SENSORS_FAN_LOW:&quot;{#DRIVER}_{#SENSOR}&quot;}</expression>
-                                    <name>Fan '{#DRIVER}' - '{#LABEL}' speed is too low ({ITEM.LASTVALUE})</name>
+                                    <name>{$SENSORS_FAN_NAME:&quot;{#DRIVER}_{#SENSOR}&quot;} '{#DRIVER}' - '{#LABEL}' speed is too low ({ITEM.LASTVALUE})</name>
                                     <priority>HIGH</priority>
                                     <tags>
                                         <tag>
@@ -127,7 +127,7 @@ return JSON.stringify(out);</parameter>
                     <item_prototypes>
                         <item_prototype>
                             <uuid>fbd5e4aaab9c4d85b24cbbaa6238804c</uuid>
-                            <name>Power '{#DRIVER}' - '{#LABEL}'</name>
+                            <name>{$SENSORS_POWER_NAME:&quot;{#DRIVER}_{#SENSOR}&quot;} '{#DRIVER}' - '{#LABEL}'</name>
                             <type>DEPENDENT</type>
                             <key>sensors.power['{#DRIVER}', '{#SENSOR}']</key>
                             <history>30d</history>
@@ -214,7 +214,7 @@ return JSON.stringify(out);</parameter>
                     <item_prototypes>
                         <item_prototype>
                             <uuid>b6f0377dd1a5484482811100d2d86a7c</uuid>
-                            <name>Temperature '{#DRIVER}' - '{#LABEL}'</name>
+                            <name>{$SENSORS_TEMP_NAME:&quot;{#DRIVER}_{#SENSOR}&quot;} '{#DRIVER}' - '{#LABEL}'</name>
                             <type>DEPENDENT</type>
                             <key>sensors.temp['{#DRIVER}', '{#SENSOR}']</key>
                             <history>30d</history>
@@ -253,7 +253,7 @@ return JSON.stringify(out);</parameter>
                                     <expression>min(/Sensors/sensors.temp['{#DRIVER}', '{#SENSOR}'],600s)&gt;{$SENSORS_TEMP_CRIT:&quot;{#DRIVER}_{#SENSOR}&quot;}</expression>
                                     <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
                                     <recovery_expression>min(/Sensors/sensors.temp['{#DRIVER}', '{#SENSOR}'],600s)&lt;={$SENSORS_TEMP_CRIT:&quot;{#DRIVER}_{#SENSOR}&quot;}-{$SENSORS_TEMP_HYST}</recovery_expression>
-                                    <name>Temperature '{#DRIVER}' - '{#LABEL}' is critical ({ITEM.LASTVALUE})</name>
+                                    <name>{$SENSORS_TEMP_NAME:&quot;{#DRIVER}_{#SENSOR}&quot;} '{#DRIVER}' - '{#LABEL}' is critical ({ITEM.LASTVALUE})</name>
                                     <priority>HIGH</priority>
                                     <tags>
                                         <tag>
@@ -271,7 +271,7 @@ return JSON.stringify(out);</parameter>
                                     <expression>min(/Sensors/sensors.temp['{#DRIVER}', '{#SENSOR}'],600s)&gt;{$SENSORS_TEMP_HIGH:&quot;{#DRIVER}_{#SENSOR}&quot;}</expression>
                                     <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
                                     <recovery_expression>min(/Sensors/sensors.temp['{#DRIVER}', '{#SENSOR}'],600s)&lt;={$SENSORS_TEMP_HIGH:&quot;{#DRIVER}_{#SENSOR}&quot;}-{$SENSORS_TEMP_HYST}</recovery_expression>
-                                    <name>Temperature '{#DRIVER}' - '{#LABEL}' is high ({ITEM.LASTVALUE})</name>
+                                    <name>{$SENSORS_TEMP_NAME:&quot;{#DRIVER}_{#SENSOR}&quot;} '{#DRIVER}' - '{#LABEL}' is high ({ITEM.LASTVALUE})</name>
                                     <priority>AVERAGE</priority>
                                     <tags>
                                         <tag>
@@ -331,7 +331,7 @@ return JSON.stringify(out);</parameter>
                     <item_prototypes>
                         <item_prototype>
                             <uuid>24a45e2fea8f498bb1bb9b6be11670cb</uuid>
-                            <name>Voltage '{#DRIVER}' - '{#LABEL}'</name>
+                            <name>{$SENSORS_VOLTAGE_NAME:&quot;{#DRIVER}_{#SENSOR}&quot;} '{#DRIVER}' - '{#LABEL}'</name>
                             <type>DEPENDENT</type>
                             <key>sensors.voltage['{#DRIVER}', '{#SENSOR}']</key>
                             <history>30d</history>
@@ -368,7 +368,7 @@ return JSON.stringify(out);</parameter>
                                 <trigger_prototype>
                                     <uuid>d74a773d56f442f59efc3691c52a77dc</uuid>
                                     <expression>min(/Sensors/sensors.voltage['{#DRIVER}', '{#SENSOR}'],300s)&gt;{$SENSORS_VOLTAGE_HIGH:&quot;{#DRIVER}_{#SENSOR}&quot;}</expression>
-                                    <name>Voltage '{#DRIVER}' - '{#LABEL}' is too high ({ITEM.LASTVALUE})</name>
+                                    <name>{$SENSORS_VOLTAGE_NAME:&quot;{#DRIVER}_{#SENSOR}&quot;} '{#DRIVER}' - '{#LABEL}' is too high ({ITEM.LASTVALUE})</name>
                                     <priority>AVERAGE</priority>
                                     <tags>
                                         <tag>
@@ -380,7 +380,7 @@ return JSON.stringify(out);</parameter>
                                 <trigger_prototype>
                                     <uuid>2a6fdd9075c544f2b77b32be36bb2819</uuid>
                                     <expression>max(/Sensors/sensors.voltage['{#DRIVER}', '{#SENSOR}'],300s)&lt;{$SENSORS_VOLTAGE_LOW:&quot;{#DRIVER}_{#SENSOR}&quot;}</expression>
-                                    <name>Voltage '{#DRIVER}' - '{#LABEL}' is too low ({ITEM.LASTVALUE})</name>
+                                    <name>{$SENSORS_VOLTAGE_NAME:&quot;{#DRIVER}_{#SENSOR}&quot;} '{#DRIVER}' - '{#LABEL}' is too low ({ITEM.LASTVALUE})</name>
                                     <priority>AVERAGE</priority>
                                     <tags>
                                         <tag>
@@ -439,6 +439,16 @@ return JSON.stringify(out);</parameter>
                     <value>0</value>
                 </macro>
                 <macro>
+                    <macro>{$SENSORS_FAN_NAME}</macro>
+                    <value>Fan</value>
+                    <description>Set e.g. {$SENSORS_FAN_NAME:&quot;it8688_fan1&quot;} to rename a given instance at host level.</description>
+                </macro>
+                <macro>
+                    <macro>{$SENSORS_POWER_NAME}</macro>
+                    <value>Power</value>
+                    <description>Set e.g. {$SENSORS_POWER_NAME:&quot;driver_sensor&quot;} to rename a given instance at host level.</description>
+                </macro>
+                <macro>
                     <macro>{$SENSORS_TEMP_CRIT}</macro>
                     <value>80</value>
                 </macro>
@@ -451,12 +461,22 @@ return JSON.stringify(out);</parameter>
                     <value>5</value>
                 </macro>
                 <macro>
+                    <macro>{$SENSORS_TEMP_NAME}</macro>
+                    <value>Temperature</value>
+                    <description>Set e.g. {$SENSORS_TEMP_NAME:&quot;k10temp_Tctl&quot;} to rename a given instance at host level.</description>
+                </macro>
+                <macro>
                     <macro>{$SENSORS_VOLTAGE_HIGH}</macro>
                     <value>1000</value>
                 </macro>
                 <macro>
                     <macro>{$SENSORS_VOLTAGE_LOW}</macro>
                     <value>0</value>
+                </macro>
+                <macro>
+                    <macro>{$SENSORS_VOLTAGE_NAME}</macro>
+                    <value>Voltage</value>
+                    <description>Set e.g. {$SENSORS_VOLTAGE_NAME:&quot;it8688_in1&quot;} to rename a given instance at host level.</description>
                 </macro>
             </macros>
         </template>


### PR DESCRIPTION
This allows customizing item names using user macros with context, as was already in place for trigger values. See the README.md for more information.